### PR TITLE
Add MV3 Chrome compatibility

### DIFF
--- a/build/copy.js
+++ b/build/copy.js
@@ -157,34 +157,67 @@ async function handleManifest(srcPath, dstPath) {
     const srcData = await fs.promises.readFile(srcPath, 'utf-8')
     const data = JSON.parse(srcData)
 
-    // Remove unsupported keys
+    // Base adjustments for Chromium MV3
+    data.manifest_version = 3
     delete data.page_action
     delete data.browser_specific_settings
 
-    // Reset commands
-    for (const key of Object.keys(data.commands)) {
-      const cmd = data.commands[key]
-      if (key === '_execute_sidebar_action') {
-        cmd.suggested_key.windows = cmd.suggested_key.default
-      } else {
-        delete cmd.suggested_key
+    const browserAction = data.browser_action ?? {}
+    data.action = {
+      default_icon: browserAction.default_icon,
+      default_title: browserAction.default_title,
+      theme_icons: browserAction.theme_icons,
+    }
+    delete data.browser_action
+
+    if (data.sidebar_action?.default_panel) {
+      data.side_panel = { default_path: data.sidebar_action.default_panel }
+    }
+    delete data.sidebar_action
+
+    data.background = {
+      service_worker: 'bg/background.js',
+      type: 'module',
+    }
+
+    const commands = data.commands ?? {}
+    for (const key of Object.keys(commands)) {
+      const cmd = commands[key]
+      if (!cmd) continue
+      if (cmd.suggested_key) {
+        if (key === '_execute_sidebar_action' && cmd.suggested_key.windows) {
+          cmd.suggested_key.windows = cmd.suggested_key.default
+        } else {
+          delete cmd.suggested_key
+        }
       }
     }
 
-    // Clean up permissions
-    const contextualIdentitiesIndex = data.permissions.indexOf('contextualIdentities')
-    if (contextualIdentitiesIndex !== -1) data.permissions.splice(contextualIdentitiesIndex, 1)
-    const menusIndex = data.permissions.indexOf('menus')
-    if (menusIndex !== -1) data.permissions.splice(menusIndex, 1)
-    const menusOverrideContextIndex = data.permissions.indexOf('menus.overrideContext')
-    if (menusOverrideContextIndex !== -1) data.permissions.splice(menusOverrideContextIndex, 1)
-    const tabHideIndex = data.permissions.indexOf('tabHide')
-    if (tabHideIndex !== -1) data.permissions.splice(tabHideIndex, 1)
-    const proxyIndex = data.optional_permissions.indexOf('proxy')
-    if (proxyIndex !== -1) data.optional_permissions.splice(proxyIndex, 1)
-    data.permissions.push('proxy')
+    const permissions = new Set(data.permissions ?? [])
+    permissions.delete('contextualIdentities')
+    permissions.delete('tabHide')
+    permissions.delete('menus.overrideContext')
+    permissions.delete('theme')
+    if (permissions.delete('menus')) permissions.add('contextMenus')
+    permissions.add('sidePanel')
+    data.permissions = Array.from(permissions)
 
-    const dstData = JSON.stringify(data)
+    const optionalPermissions = new Set(data.optional_permissions ?? [])
+    optionalPermissions.delete('tabHide')
+    data.optional_permissions = Array.from(optionalPermissions)
+
+    const allUrlsIndex = data.optional_permissions.indexOf('<all_urls>')
+    if (allUrlsIndex !== -1) data.optional_permissions.splice(allUrlsIndex, 1)
+    data.host_permissions = ['<all_urls>']
+
+    data.web_accessible_resources = [
+      {
+        resources: ['**/*'],
+        matches: ['<all_urls>'],
+      },
+    ]
+
+    const dstData = JSON.stringify(data, null, 2)
     await fs.promises.writeFile(dstPath, dstData)
   }
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,10 @@
     "src": "./src"
   },
   "browserslist": [
-    "Firefox >= 128"
+    "Firefox >= 128",
+    "Chrome >= 120"
   ],
-  "sideEffects": false
+  "sideEffects": [
+    "src/polyfills/browser.ts"
+  ]
 }

--- a/src/bg/background.ts
+++ b/src/bg/background.ts
@@ -1,3 +1,5 @@
+import 'src/polyfills/browser'
+
 import { InstanceType } from 'src/types'
 import { NOID } from 'src/defaults'
 import * as IPC from 'src/services/ipc'
@@ -71,6 +73,11 @@ void (async function main() {
   await Sidebar.loadNav()
   Sidebar.setupListeners()
 
+  const sidePanel = (browser as unknown as {
+    sidePanel?: { setOptions?: (options: { path: string; enabled: boolean }) => Promise<void> | void }
+  }).sidePanel
+  void sidePanel?.setOptions?.({ path: './sidebar/sidebar.html', enabled: true })
+
   WebReq.updateReqHandlers()
 
   Tabs.setupTabsListeners()
@@ -101,7 +108,7 @@ void (async function main() {
     }
   })
 
-  window.getSideberyState = () => {
+  ;(globalThis as any).getSideberyState = () => {
     // prettier-ignore
     return {
       IPC, Info, Settings, Windows, Tabs, Containers,
@@ -123,8 +130,9 @@ void (async function main() {
 function initToolbarButton(): void {
   Menu.createBrowserActionMenu()
 
-  browser.browserAction.onClicked.addListener((_, info): void => {
+  const browserAction = browser.action ?? browser.browserAction
+  browserAction?.onClicked.addListener((_, info): void => {
     if (info && info.button === 1) browser.runtime.openOptionsPage()
-    else browser.sidebarAction.toggle()
+    else if (browser.sidebarAction?.toggle) browser.sidebarAction.toggle()
   })
 }

--- a/src/components/bookmark-node.vue
+++ b/src/components/bookmark-node.vue
@@ -310,7 +310,7 @@ function onCtxMenu(e: MouseEvent): void {
   }
 
   let nativeCtx = { context: 'bookmark', bookmarkId: props.node.id } as const
-  browser.menus.overrideContext(nativeCtx)
+  browser.menus?.overrideContext?.(nativeCtx)
 
   if (!Selection.isBookmarks()) Selection.selectBookmark(props.node.id)
 

--- a/src/page.setup/components/popup.container-config.vue
+++ b/src/page.setup/components/popup.container-config.vue
@@ -173,6 +173,7 @@ function onNameInput(value: string): void {
 }
 
 function updateContainer(): void {
+  if (!Containers.isSupported) return
   if (!props.conf.name || !props.conf.id) return
   browser.contextualIdentities.update(props.conf.id, {
     name: props.conf.name,

--- a/src/page.setup/components/popup.import-config.vue
+++ b/src/page.setup/components/popup.import-config.vue
@@ -425,6 +425,7 @@ function requestPermissions(): void {
 type OldNewIds = Record<string, string>
 async function importContainers(backup: BackupData): Promise<OldNewIds> {
   if (!backup.containers) throw 'No containers data'
+  if (!Containers.isSupported) return {}
 
   let ffContainers = await browser.contextualIdentities.query({})
   let storage = await browser.storage.local.get<Stored>({ containers: {} })

--- a/src/page.setup/components/settings.containers.vue
+++ b/src/page.setup/components/settings.containers.vue
@@ -59,6 +59,8 @@ onMounted(() => SetupPage.registerEl('settings_containers', el.value))
  * Create container
  */
 async function createContainer(): Promise<void> {
+  if (!Containers.isSupported) return
+
   let containersCount = Object.keys(Containers.reactive.byId).length
   const newFFContainer = await browser.contextualIdentities.create({
     name: `New Container ${containersCount + 1}`,
@@ -80,6 +82,8 @@ async function createContainer(): Promise<void> {
  * Remove container
  */
 async function removeContainer(container: Container): Promise<void> {
+  if (!Containers.isSupported) return
+
   let preMsg = translate('settings.contianer_remove_confirm_prefix')
   let postMsg = translate('settings.contianer_remove_confirm_postfix')
   if (window.confirm(preMsg + container.name + postMsg)) {

--- a/src/page.setup/components/snapshots.tab.vue
+++ b/src/page.setup/components/snapshots.tab.vue
@@ -144,8 +144,8 @@ function onTabDragStart(e: DragEvent): void {
 }
 
 async function openTab(tab: SnapTabState): Promise<void> {
-  const activePanel = await browser.sidebarAction
-    .isOpen({ windowId: Windows.id })
+  const sidebarAction = browser.sidebarAction
+  const activePanel = await sidebarAction?.isOpen?.({ windowId: Windows.id })
     .then(isOpen => (isOpen ? IPC.sidebar(Windows.id, 'getActivePanelConfig') : undefined))
     .catch(() => undefined)
 

--- a/src/page.setup/components/snapshots.vue
+++ b/src/page.setup/components/snapshots.vue
@@ -281,8 +281,8 @@ async function openSelectedTabs(how: SnapOpenType): Promise<void> {
   }
 
   if (how === SnapOpenType.CurrentPanel) {
-    const activePanel = await browser.sidebarAction
-      .isOpen({ windowId: Windows.id })
+    const sidebarAction = browser.sidebarAction
+    const activePanel = await sidebarAction?.isOpen?.({ windowId: Windows.id })
       .then(isOpen => (isOpen ? IPC.sidebar(Windows.id, 'getActivePanelConfig') : undefined))
       .catch(() => undefined)
     if (Utils.isTabsPanel(activePanel)) {

--- a/src/polyfills/browser.ts
+++ b/src/polyfills/browser.ts
@@ -1,0 +1,91 @@
+if (typeof globalThis.browser === 'undefined' && typeof globalThis.chrome !== 'undefined') {
+  const chromeApi = globalThis.chrome as any
+
+  if (!chromeApi.menus && chromeApi.contextMenus) {
+    chromeApi.menus = chromeApi.contextMenus
+  }
+
+  if (!chromeApi.browserAction && chromeApi.action) {
+    chromeApi.browserAction = chromeApi.action
+  }
+
+  if (!chromeApi.sidebarAction && chromeApi.sidePanel) {
+    let isOpen = false
+
+    chromeApi.sidebarAction = {
+      setTitle() {
+        // Chromium side panel does not allow custom titles yet
+      },
+      async toggle(details?: { windowId?: number }) {
+        const targetWindowId = details?.windowId ?? chromeApi.windows?.WINDOW_ID_CURRENT
+        if (!chromeApi.sidePanel) return
+
+        if (isOpen) {
+          try {
+            await chromeApi.sidePanel.close?.({ windowId: targetWindowId })
+          } catch (err) {
+            console.warn('Sidebery: cannot close side panel', err)
+          }
+          isOpen = false
+        } else {
+          try {
+            await chromeApi.sidePanel.open({ windowId: targetWindowId })
+            isOpen = true
+          } catch (err) {
+            console.warn('Sidebery: cannot open side panel', err)
+          }
+        }
+      },
+    }
+  }
+
+  const wrapNamespace = (target: any, seen = new WeakMap()): any => {
+    if (!target || typeof target !== 'object') return target
+    if (seen.has(target)) return seen.get(target)
+
+    const proxy = new Proxy(target, {
+      get(obj, prop) {
+        const value = obj[prop]
+
+        if (typeof value === 'function') {
+          return (...args: any[]) => {
+            const lastArg = args[args.length - 1]
+            if (typeof lastArg === 'function') {
+              return value.apply(obj, args)
+            }
+
+            return new Promise((resolve, reject) => {
+              const callback = (...cbArgs: any[]) => {
+                const err = chromeApi.runtime?.lastError
+                if (err) reject(new Error(err.message))
+                else resolve(cbArgs.length > 1 ? cbArgs : cbArgs[0])
+              }
+
+              try {
+                value.call(obj, ...args, callback)
+              } catch (error) {
+                reject(error)
+              }
+            })
+          }
+        }
+
+        if (value && typeof value === 'object') {
+          if ('addListener' in value && typeof value.addListener === 'function') {
+            return value
+          }
+          return wrapNamespace(value, seen)
+        }
+
+        return value
+      },
+    })
+
+    seen.set(target, proxy)
+    return proxy
+  }
+
+  globalThis.browser = wrapNamespace(chromeApi)
+}
+
+export {}

--- a/src/popup.proxy/proxy.ts
+++ b/src/popup.proxy/proxy.ts
@@ -5,6 +5,10 @@ import { Styles } from 'src/services/styles'
 import * as IPC from 'src/services/ipc'
 import { SETUP_URL } from 'src/defaults'
 
+const contextualIdentities = (browser as unknown as {
+  contextualIdentities?: typeof browser.contextualIdentities
+}).contextualIdentities
+
 void (async function () {
   Info.setInstanceType(InstanceType.proxy)
 
@@ -90,13 +94,15 @@ void (async function () {
  * Init title
  */
 async function initTitle() {
+  if (!contextualIdentities) return
+
   const [activeTab] = await browser.tabs.query({
     currentWindow: true,
     active: true,
   })
   if (!activeTab) return
 
-  const container = await browser.contextualIdentities.get(activeTab.cookieStoreId)
+  const container = await contextualIdentities.get(activeTab.cookieStoreId)
   if (!container) return
 
   const popupTitleEl = document.getElementById('popup_title')
@@ -113,6 +119,8 @@ async function initTitle() {
  * Init static config
  */
 async function initConfigInfo() {
+  if (!contextualIdentities) return
+
   const [activeTab] = await browser.tabs.query({
     currentWindow: true,
     active: true,

--- a/src/services/containers.actions.ts
+++ b/src/services/containers.actions.ts
@@ -10,10 +10,24 @@ import { Info } from 'src/services/info'
 import { Settings } from './settings'
 import { Tabs } from './tabs.fg'
 
+const contextualIdentities = (browser as unknown as {
+  contextualIdentities?: typeof browser.contextualIdentities
+}).contextualIdentities
+
 export async function load(): Promise<void> {
+  if (!contextualIdentities) {
+    if (Info.isBg) {
+      Containers.reactive.byId = {}
+      await Store.set({ containers: {} })
+    } else {
+      Containers.reactive.byId = {}
+    }
+    return
+  }
+
   if (Info.isBg) {
     const [ffContainers, storage] = await Promise.all([
-      browser.contextualIdentities.query({}),
+      contextualIdentities.query({}),
       browser.storage.local.get<Stored>('containers'),
     ])
     const containers = storage.containers ?? {}
@@ -39,7 +53,7 @@ export async function load(): Promise<void> {
       const ffContainer = ffContainers.find(c => c.cookieStoreId === container.id)
       if (!ffContainer) {
         const conf = { name: container.name, color: container.color, icon: container.icon }
-        const newFFContainer = await browser.contextualIdentities.create(conf)
+        const newFFContainer = await contextualIdentities.create(conf)
         delete containers[id]
         container.id = newFFContainer.cookieStoreId
         container.cookieStoreId = newFFContainer.cookieStoreId
@@ -97,7 +111,9 @@ export function updateContainers(newContainers?: Record<ID, Container> | null): 
 }
 
 export async function create(name: string, color: string, icon: string): Promise<Container> {
-  const newRawContainer = await browser.contextualIdentities.create({ name, color, icon })
+  if (!contextualIdentities) throw new Error('Containers API is not available')
+
+  const newRawContainer = await contextualIdentities.create({ name, color, icon })
   const newContainer = Utils.recreateNormalizedObject(
     newRawContainer as Container,
     DEFAULT_CONTAINER

--- a/src/services/containers.handlers.ts
+++ b/src/services/containers.handlers.ts
@@ -7,13 +7,22 @@ import { Tabs } from 'src/services/tabs.fg'
 import { Info } from 'src/services/info'
 
 export function setupContainersListeners(): void {
+  const contextualIdentities = (browser as unknown as {
+    contextualIdentities?: typeof browser.contextualIdentities
+  }).contextualIdentities
+
+  if (!contextualIdentities) {
+    Store.onKeyChange('containers', Containers.updateContainers)
+    return
+  }
+
   if (Info.isBg) {
-    browser.contextualIdentities.onCreated.addListener(onContainerCreated)
-    browser.contextualIdentities.onRemoved.addListener(onContainerRemovedBg)
-    browser.contextualIdentities.onUpdated.addListener(onContainerUpdated)
+    contextualIdentities.onCreated.addListener(onContainerCreated)
+    contextualIdentities.onRemoved.addListener(onContainerRemovedBg)
+    contextualIdentities.onUpdated.addListener(onContainerUpdated)
     Store.onKeyChange('containers', Containers.updateContainers)
   } else {
-    browser.contextualIdentities.onRemoved.addListener(onContainerRemovedFg)
+    contextualIdentities.onRemoved.addListener(onContainerRemovedFg)
     Store.onKeyChange('containers', Containers.updateContainers)
   }
 }

--- a/src/services/containers.ts
+++ b/src/services/containers.ts
@@ -13,6 +13,7 @@ export interface ContainerProxy {
 }
 
 export const Containers = {
+  isSupported: !!(browser as unknown as { contextualIdentities?: unknown }).contextualIdentities,
   reactive: { byId: {} } as ContainersState,
 
   ...ContainersHandlers,

--- a/src/services/ipc.ts
+++ b/src/services/ipc.ts
@@ -1,3 +1,5 @@
+import 'src/polyfills/browser'
+
 import { AnyFunc, Actions, Message, InstanceType, ActionsKeys } from 'src/types'
 import { ActionsType } from 'src/types'
 import { NOID } from 'src/defaults'

--- a/src/services/sidebar.actions.ts
+++ b/src/services/sidebar.actions.ts
@@ -2235,9 +2235,9 @@ export function updateSidebarTitle(delay = 456): void {
       const panel = Sidebar.panelsById[Sidebar.activePanelId]
       if (!panel) return
 
-      browser.sidebarAction.setTitle({ title: panel.name, windowId: Windows.id })
+      browser.sidebarAction?.setTitle?.({ title: panel.name, windowId: Windows.id })
     } else {
-      browser.sidebarAction.setTitle({ title: 'Sidebery', windowId: Windows.id })
+      browser.sidebarAction?.setTitle?.({ title: 'Sidebery', windowId: Windows.id })
     }
   }, delay)
 }

--- a/src/services/tabs.fg.move.ts
+++ b/src/services/tabs.fg.move.ts
@@ -386,9 +386,12 @@ async function moveTabsToWin(tabIds: ID[], dst: DstPlaceInfo): Promise<void> {
 
   let sidebarIsOpen
   if (dst.windowId !== Windows.id) {
-    sidebarIsOpen = await browser.sidebarAction
-      .isOpen({ windowId: dst.windowId })
-      .catch(() => false)
+    const sidebarAction = browser.sidebarAction
+    if (sidebarAction?.isOpen) {
+      sidebarIsOpen = await sidebarAction.isOpen({ windowId: dst.windowId }).catch(() => false)
+    } else {
+      sidebarIsOpen = false
+    }
   }
 
   let moved

--- a/src/sidebar/components/bar.navigation.vue
+++ b/src/sidebar/components/bar.navigation.vue
@@ -445,7 +445,7 @@ function onNavCtxMenu(e: MouseEvent, item: NavItem) {
   Menu.blockCtxMenu()
 
   let nativeCtx = { showDefaults: false }
-  browser.menus.overrideContext(nativeCtx)
+  browser.menus?.overrideContext?.(nativeCtx)
 
   let type: MenuType
   if (panel.type === PanelType.bookmarks) type = MenuType.BookmarksPanel

--- a/src/sidebar/components/bar.new-tab.vue
+++ b/src/sidebar/components/bar.new-tab.vue
@@ -293,7 +293,7 @@ function onNewTabCtxMenu(e: MouseEvent): void {
   }
 
   let nativeCtx = { showDefaults: false }
-  browser.menus.overrideContext(nativeCtx)
+  browser.menus?.overrideContext?.(nativeCtx)
 
   if (!Selection.isSet()) Selection.selectNewTabBtn(props.panel.id)
 

--- a/src/sidebar/components/bookmark-card.vue
+++ b/src/sidebar/components/bookmark-card.vue
@@ -159,7 +159,7 @@ function onCtxMenu(e: MouseEvent): void {
   }
 
   let nativeCtx = { context: 'bookmark', bookmarkId: props.node.id } as const
-  browser.menus.overrideContext(nativeCtx)
+  browser.menus?.overrideContext?.(nativeCtx)
 
   if (!Selection.isBookmarks()) Selection.selectBookmark(props.node.id)
 

--- a/src/sidebar/components/history-item.vue
+++ b/src/sidebar/components/history-item.vue
@@ -162,7 +162,7 @@ function onCtxMenu(e: MouseEvent, visit: Visit): void {
     return
   }
 
-  browser.menus.overrideContext({ showDefaults: false })
+  browser.menus?.overrideContext?.({ showDefaults: false })
 
   if (!Selection.isSet()) Selection.selectHistory(visit.id)
 

--- a/src/sidebar/components/panel.bookmarks.vue
+++ b/src/sidebar/components/panel.bookmarks.vue
@@ -284,7 +284,7 @@ function onNavCtxMenu(e: MouseEvent): void {
   }
 
   let nativeCtx = { showDefaults: false }
-  browser.menus.overrideContext(nativeCtx)
+  browser.menus?.overrideContext?.(nativeCtx)
 
   if (!Selection.isSet()) Selection.selectNavItem(props.panel.id)
   Menu.open(MenuType.BookmarksPanel)

--- a/src/sidebar/components/panel.tabs.vue
+++ b/src/sidebar/components/panel.tabs.vue
@@ -189,7 +189,7 @@ function onNavCtxMenu(e: MouseEvent): void {
   }
 
   let nativeCtx = { showDefaults: false }
-  browser.menus.overrideContext(nativeCtx)
+  browser.menus?.overrideContext?.(nativeCtx)
 
   if (!Selection.isSet()) Selection.selectNavItem(props.panel.id)
   Menu.open(MenuType.TabsPanel)

--- a/src/sidebar/components/popup.container-config.vue
+++ b/src/sidebar/components/popup.container-config.vue
@@ -85,6 +85,11 @@ async function onSave(): Promise<void> {
   const popup = Popups.reactive.containerConfigPopup
 
   if (!valid.value) return
+  if (!Containers.isSupported) {
+    Popups.reactive.containerConfigPopup.done(null)
+    Popups.reactive.containerConfigPopup = null
+    return
+  }
 
   let container = Containers.reactive.byId[Popups.reactive.containerConfigPopup.id]
   if (container) {

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -438,7 +438,7 @@ function onCtxMenu(e: MouseEvent): void {
     return
   }
 
-  browser.menus.overrideContext({ context: 'tab', tabId: tab.id })
+  browser.menus?.overrideContext?.({ context: 'tab', tabId: tab.id })
 
   if (!Selection.isSet()) select()
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import 'src/polyfills/browser'
+
 import { GroupConfig, AnyFunc, NavItem, NavBtn, NavSpace, Panel, PanelConfig, Tab } from './types'
 import { TabsPanel, BookmarksPanel, PanelType, HistoryPanel, SyncPanel, ItemInfo } from './types'
 import { NavItemClass, SubListTitleInfo, RGBA, RGB, AnyAsyncFunc, DataUriImage } from './types'


### PR DESCRIPTION
## Summary
- convert the Chromium build pipeline to emit an MV3 manifest, side panel entry, and Chrome-specific permissions
- add a Chrome webextension polyfill so promise-based browser APIs work in MV3 service workers and other contexts
- guard container-dependent features and Firefox-only menu overrides when the APIs are unavailable

## Testing
- npm run build -- --chromium

------
https://chatgpt.com/codex/tasks/task_b_68d7a3ebd4ac832cb387e92a3bfd65cf